### PR TITLE
update MONGODB_URI env

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,30 @@
+# Stage 1: Build
+FROM node:20-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY . .
+RUN npm run build && npm run build-server
+# Remove devDependencies from node_modules
+RUN npm prune --omit=dev
+
+# Stage 2: Run
+FROM node:20-slim
+
+WORKDIR /app
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/app.js ./
+COPY --from=build /app/package.json ./
+COPY --from=build /app/lib ./lib
+COPY --from=build /app/node_modules ./node_modules
+
+ENV NODE_ENV=production
+
+EXPOSE 8080
+
+# MONGODB_URI can be set at runtime
+CMD ["node", "app.js"]

--- a/app.js
+++ b/app.js
@@ -54,6 +54,13 @@ app.use('/cloud-mongodb-com', atlasRouter);
 
 app.use('/connections', connectionRouter);
 
+// Serve the default MongoDB URI from environment variable
+app.get('/default-connection', (req, res) => {
+    res.json({
+        uri: process.env.MONGODB_URI || ''
+    });
+});
+
 app.get('*', (req, res) => {
     res.sendFile(path.join(distPath, 'index.html'));
 });


### PR DESCRIPTION
## Add support for default MongoDB connection string from environment variable

### Description

This PR adds the ability to provide a default MongoDB connection string to Compass Web via the `MONGODB_URI` environment variable. When the application starts and there are no saved connections, it will automatically create a default connection using the value from `MONGODB_URI`. This makes it easier to pre-configure the app for users, especially in Docker or cloud environments.

### Changes

- The backend exposes the `MONGODB_URI` value at the `/default-connection` endpoint.
- On frontend load, if there are no saved connections, the app will create a new connection using the value from `/default-connection`.
- The default connection will appear in the sidebar and can be used immediately.

### How to use

- Set the `MONGODB_URI` environment variable when running the app or Docker container.
- On first load, the default connection will be available in the UI.
