### PR TITLE
feat: Add `base-route` config

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -53,8 +53,27 @@ fastify.register(require('@fastify/multipart'));
 registerAuth(fastify);
 
 fastify.after(() => {
-  fastify.register(require('./ws'));
-  fastify.register(require('./routes'));
+  const baseRoute = args.baseRoute;
+
+  fastify.register(require('./ws'), {
+    prefix: baseRoute ? '/' + baseRoute : undefined,
+  });
+  fastify.register(require('./routes'), {
+    prefix: baseRoute ? `/${baseRoute}/api` : '/api',
+  });
+
+  fastify.setNotFoundHandler((request, reply) => {
+    if (baseRoute && !request.url.startsWith('/' + baseRoute)) {
+      reply.status(404).send({ error: 'Not found' });
+      return;
+    }
+    const csrfToken = reply.generateCsrf();
+    reply.view('index.eta', {
+      csrfToken,
+      appName: args.appName,
+      baseRoute: baseRoute,
+    });
+  });
 });
 
 module.exports = fastify;

--- a/src/cli.js
+++ b/src/cli.js
@@ -84,6 +84,11 @@ function readCliArgs() {
       description: 'Enable upload sample documents to GenAI service.',
       default: false,
     })
+    .option('base-route', {
+      type: 'string',
+      description: 'Base route prefix for all application routes, e.g. /app',
+      default: '',
+    })
     .options('enable-edit-connections', {
       type: 'boolean',
       description: 'Allow user to edit connections in the UI',
@@ -149,7 +154,9 @@ function readCliArgs() {
     };
   }
 
-  return { ...args, mongoURIs, basicAuth };
+  const baseRoute = args.baseRoute.trim();
+  console.log('Base Route', baseRoute);
+  return { ...args, mongoURIs, basicAuth, baseRoute };
 }
 
 module.exports = { readCliArgs };

--- a/src/connection-storage.ts
+++ b/src/connection-storage.ts
@@ -2,7 +2,10 @@ import type {
   ConnectionStorage,
   ConnectionInfo,
 } from '../compass/packages/connection-storage/src/provider';
+import { getMetaData, getAPIRoute } from './shared';
 import { openToast } from '../compass/packages/compass-components/src';
+
+const baseRoute = getMetaData('base-route') || '';
 
 export class CompassWebConnectionStorage implements ConnectionStorage {
   private readonly _defaultHeaders: Record<string, string> = {
@@ -10,20 +13,16 @@ export class CompassWebConnectionStorage implements ConnectionStorage {
   };
 
   constructor(private readonly _projectId: string) {
-    const csrfElement: HTMLMetaElement | null = document.querySelector(
-      'meta[name="csrf-token"]'
-    );
+    const csrfToken = getMetaData('csrf-token');
 
-    if (csrfElement?.content) {
-      this._defaultHeaders['csrf-token'] = csrfElement.content;
+    if (csrfToken) {
+      this._defaultHeaders['csrf-token'] = csrfToken;
     }
   }
 
   async loadAll(): Promise<ConnectionInfo[]> {
     try {
-      const resp = await fetch(
-        `/explorer/v1/groups/${this._projectId}/clusters/connectionInfo`
-      );
+      const resp = await fetch(getAPIRoute('connection-info'));
 
       if (!resp.ok) {
         const error = (await resp.json()).error || 'Unknown error';
@@ -36,7 +35,7 @@ export class CompassWebConnectionStorage implements ConnectionStorage {
         connectionOptions: {
           ...conn.connectionOptions,
           lookup: () => ({
-            wsURL: `/clusterConnection/${this._projectId}`,
+            wsURL: baseRoute ? `/${baseRoute}/ws` : '/ws',
           }),
         },
       }));
@@ -61,14 +60,11 @@ export class CompassWebConnectionStorage implements ConnectionStorage {
     connectionInfo: ConnectionInfo;
   }): Promise<void> {
     try {
-      const resp = await fetch(
-        `/explorer/v1/groups/${this._projectId}/clusters/connectionInfo`,
-        {
-          method: 'POST',
-          headers: this._defaultHeaders,
-          body: JSON.stringify(connectionInfo),
-        }
-      );
+      const resp = await fetch(getAPIRoute('connection-info'), {
+        method: 'POST',
+        headers: this._defaultHeaders,
+        body: JSON.stringify(connectionInfo),
+      });
 
       if (!resp.ok) {
         const error = (await resp.json()).error || 'Unknown error';
@@ -85,12 +81,9 @@ export class CompassWebConnectionStorage implements ConnectionStorage {
 
   async delete({ id }: { id: string }): Promise<void> {
     try {
-      const resp = await fetch(
-        `/explorer/v1/groups/${this._projectId}/clusters/connectionInfo/${id}`,
-        {
-          method: 'DELETE',
-        }
-      );
+      const resp = await fetch(getAPIRoute(`connection-info/${id}`), {
+        method: 'DELETE',
+      });
 
       if (!resp.ok) {
         const error = (await resp.json()).error || 'Unknown error';

--- a/src/export.ts
+++ b/src/export.ts
@@ -16,6 +16,7 @@ import {
 } from '../compass/packages/compass-import-export/src/components/export-toast';
 import type { ExportJSONFormat } from '../compass/packages/compass-import-export/src/export/export-json';
 import type { ExportThunkAction } from '../compass/packages/compass-import-export/src/stores/export-store';
+import { getMetaData, getAPIRoute } from './shared';
 
 type SelectFieldsToExportAction = {
   type: ExportActionTypes.SelectFieldsToExport;
@@ -36,6 +37,8 @@ type FetchFieldsToExportSuccessAction = {
   fieldsToExport: FieldsToExport;
   aborted?: boolean;
 };
+
+const csrfToken = getMetaData('csrf-token') || '';
 
 export const runExport = ({
   fileType,
@@ -146,19 +149,16 @@ export const runExport = ({
       let response;
       if (aggregation) {
         if (fileType === 'csv') {
-          response = await fetch('/export-csv', {
+          response = await fetch(getAPIRoute('export-csv'), {
             method: 'POST',
             body: JSON.stringify({ ...baseExportOptions, aggregation }),
             headers: {
               'Content-Type': 'application/json',
-              // @ts-ignore
-              'csrf-token':
-                document.querySelector('meta[name="csrf-token"]')?.content ??
-                '',
+              'csrf-token': csrfToken,
             },
           });
         } else {
-          response = await fetch('/export-json', {
+          response = await fetch(getAPIRoute('export-json'), {
             method: 'POST',
             body: JSON.stringify({
               ...baseExportOptions,
@@ -167,28 +167,22 @@ export const runExport = ({
             }),
             headers: {
               'Content-Type': 'application/json',
-              // @ts-ignore
-              'csrf-token':
-                document.querySelector('meta[name="csrf-token"]')?.content ??
-                '',
+              'csrf-token': csrfToken,
             },
           });
         }
       } else {
         if (fileType === 'csv') {
-          response = await fetch('/export-csv', {
+          response = await fetch(getAPIRoute('export-csv'), {
             method: 'POST',
             body: JSON.stringify({ ...baseExportOptions, query }),
             headers: {
               'Content-Type': 'application/json',
-              // @ts-ignore
-              'csrf-token':
-                document.querySelector('meta[name="csrf-token"]')?.content ??
-                '',
+              'csrf-token': csrfToken,
             },
           });
         } else {
-          response = await fetch('/export-json', {
+          response = await fetch(getAPIRoute('export-json'), {
             method: 'POST',
             body: JSON.stringify({
               ...baseExportOptions,
@@ -197,10 +191,7 @@ export const runExport = ({
             }),
             headers: {
               'Content-Type': 'application/json',
-              // @ts-ignore
-              'csrf-token':
-                document.querySelector('meta[name="csrf-token"]')?.content ??
-                '',
+              'csrf-token': csrfToken,
             },
           });
         }
@@ -208,7 +199,7 @@ export const runExport = ({
 
       const exportId = await response.text();
 
-      window.open(`/export/${exportId}`, '_blank');
+      window.open(getAPIRoute(`export/${exportId}`), '_blank');
 
       // log.info(mongoLogId(1_001_000_186), 'Export', 'Finished export', {
       //     namespace,
@@ -323,7 +314,7 @@ export const selectFieldsToExport = (): ExportThunkAction<
         throw new Error('ConnectionId not provided');
       }
 
-      const res = await fetch('/gather-fields', {
+      const res = await fetch(getAPIRoute('gather-fields'), {
         method: 'POST',
         body: JSON.stringify({
           connectionId: connectionId,
@@ -333,9 +324,7 @@ export const selectFieldsToExport = (): ExportThunkAction<
         }),
         headers: {
           'Content-Type': 'application/json',
-          // @ts-ignore
-          'csrf-token':
-            document.querySelector('meta[name="csrf-token"]')?.content ?? '',
+          'csrf-token': csrfToken,
         },
       });
 

--- a/src/import.ts
+++ b/src/import.ts
@@ -32,6 +32,9 @@ import {
   ErrorJSON,
   ImportResult,
 } from '../compass/packages/compass-import-export/src/import/import-types';
+import { getMetaData, getAPIRoute } from './shared';
+
+const csrfToken = getMetaData('csrf-token') || '';
 
 function csvHeaderNameToFieldName(name: string) {
   return name.replace(/\[\d+\]/g, '[]');
@@ -64,13 +67,11 @@ const loadCSVPreviewDocs = (file: File): ImportThunkAction<Promise<void>> => {
       formData.append('file', file);
       formData.append('json', JSON.stringify({ delimiter, newline }));
 
-      let resp = await fetch('/list-csv-fields', {
+      let resp = await fetch(getAPIRoute('list-csv-fields'), {
         method: 'POST',
         body: formData,
         headers: {
-          // @ts-ignore
-          'csrf-token':
-            document.querySelector('meta[name="csrf-token"]')?.content ?? '',
+          'csrf-token': csrfToken,
         },
       });
 
@@ -182,13 +183,11 @@ const loadTypes = (
         })
       );
 
-      const resp = await fetch('/analyze-csv-fields', {
+      const resp = await fetch(getAPIRoute('analyze-csv-fields'), {
         method: 'POST',
         body: formData,
         headers: {
-          // @ts-ignore
-          'csrf-token':
-            document.querySelector('meta[name="csrf-token"]')?.content ?? '',
+          'csrf-token': csrfToken,
         },
       });
 
@@ -242,13 +241,11 @@ export const selectImportFile = (
       const formData = new FormData();
       formData.append('file', file);
 
-      const resp = await fetch('/guess-filetype', {
+      const resp = await fetch(getAPIRoute('guess-filetype'), {
         method: 'POST',
         body: formData,
         headers: {
-          // @ts-ignore
-          'csrf-token':
-            document.querySelector('meta[name="csrf-token"]')?.content ?? '',
+          'csrf-token': csrfToken,
         },
       });
 
@@ -402,13 +399,11 @@ export const startImport = (file: File): ImportThunkAction<Promise<void>> => {
           })
         );
 
-        const resp = await fetch('/upload-csv', {
+        const resp = await fetch(getAPIRoute('upload-csv'), {
           method: 'POST',
           body: formData,
           headers: {
-            // @ts-ignore
-            'csrf-token':
-              document.querySelector('meta[name="csrf-token"]')?.content ?? '',
+            'csrf-token': csrfToken,
           },
         });
 
@@ -423,13 +418,11 @@ export const startImport = (file: File): ImportThunkAction<Promise<void>> => {
             connectionId,
           })
         );
-        const resp = await fetch('/upload-json', {
+        const resp = await fetch(getAPIRoute('upload-json'), {
           method: 'POST',
           body: formData,
           headers: {
-            // @ts-ignore
-            'csrf-token':
-              document.querySelector('meta[name="csrf-token"]')?.content ?? '',
+            'csrf-token': csrfToken,
           },
         });
 

--- a/src/index.eta
+++ b/src/index.eta
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csrf-token" content="<%= it.csrfToken %>" />
+    <meta name="base-route" content="<%= it.baseRoute %>" />
     <title><%= it.appName %></title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,12 +11,11 @@ import {
 import { useWorkspaceTabRouter } from '../compass/packages/compass-web/sandbox/sandbox-workspace-tab-router';
 import { type AllPreferences } from '../compass/packages/compass-preferences-model/src';
 import { compassWebLogger } from './logger';
+import { getAPIRoute } from './shared';
 import { CompassWebConnectionStorage } from './connection-storage';
 import { SandboxConnectionStorageProvider } from '../compass/packages/compass-web/src/connection-storage';
+
 interface ProjectParams {
-  projectId: string;
-  orgId: string;
-  appName: string;
   preferences: Partial<AllPreferences>;
 }
 
@@ -69,22 +68,10 @@ const App = () => {
     React.useState<ProjectParams | null>(null);
 
   useEffect(() => {
-    void fetch('/projectId')
-      .then(async (res) => {
-        const projectId = await res.text();
-
-        if (!projectId) {
-          throw new Error('Failed to get projectId');
-        }
-        const { orgId, appName, preferences } = await fetch(
-          `/cloud-mongodb-com/v2/${projectId}/params`
-        ).then((res) => {
-          return res.json();
-        });
+    fetch(getAPIRoute('settings'))
+      .then((res) => res.json())
+      .then(({ preferences }) => {
         setProjectParams({
-          projectId,
-          orgId,
-          appName,
           preferences,
         });
       })
@@ -102,12 +89,12 @@ const App = () => {
       {projectParams ? (
         <WithConnectionStorageProvider
           preferences={projectParams.preferences}
-          projectId={projectParams.projectId}
+          projectId="-"
         >
           <CompassWeb
-            projectId={projectParams.projectId}
-            orgId={projectParams.orgId}
-            appName={projectParams.appName}
+            projectId="-"
+            orgId="-"
+            appName="Compass Web"
             onActiveWorkspaceTabChange={updateCurrentTab}
             initialWorkspace={currentTab ?? undefined}
             initialPreferences={{

--- a/src/routes.js
+++ b/src/routes.js
@@ -60,87 +60,67 @@ module.exports = function (fastify, opts, done) {
     });
   });
 
-  fastify.get('/projectId', (request, reply) => {
-    reply.type('text/plain').send(args.projectId);
-  });
+  fastify.get('/settings', (request, reply) => {
+    const preferences = settings;
 
-  fastify.get('/cloud-mongodb-com/v2/:projectId/params', (request, reply) => {
-    if (request.params.projectId == args.projectId) {
-      const preferences = settings;
-
-      reply.send({
-        orgId: args.orgId,
-        projectId: args.projectId,
-        appName: args.appName,
-        preferences: {
-          ...preferences,
-          enableGenAIFeaturesAtlasOrg: preferences.enableGenAIFeatures,
-          enableGenAIFeaturesAtlasProject: preferences.enableGenAIFeatures,
-          enableGenAISampleDocumentPassing:
-            preferences.enableGenAISampleDocumentPassing,
-          enableGenAISampleDocumentPassingOnAtlasProject:
-            preferences.enableGenAISampleDocumentPassing,
-          optInDataExplorerGenAIFeatures:
-            preferences.optInDataExplorerGenAIFeatures ?? false,
-          cloudFeatureRolloutAccess: {
-            GEN_AI_COMPASS: preferences.enableGenAIFeatures,
-          },
+    reply.send({
+      orgId: args.orgId,
+      projectId: args.projectId,
+      appName: args.appName,
+      preferences: {
+        ...preferences,
+        enableGenAIFeaturesAtlasOrg: preferences.enableGenAIFeatures,
+        enableGenAIFeaturesAtlasProject: preferences.enableGenAIFeatures,
+        enableGenAISampleDocumentPassing:
+          preferences.enableGenAISampleDocumentPassing,
+        enableGenAISampleDocumentPassingOnAtlasProject:
+          preferences.enableGenAISampleDocumentPassing,
+        optInDataExplorerGenAIFeatures:
+          preferences.optInDataExplorerGenAIFeatures ?? false,
+        cloudFeatureRolloutAccess: {
+          GEN_AI_COMPASS: preferences.enableGenAIFeatures,
         },
-      });
-    } else {
-      reply.status(404).send({
-        message: 'Project not found',
-      });
-    }
+        wsBaseUrl: args.baseRoute ? '/' + args.baseRoute : '',
+        cloudBaseUrl: args.baseRoute ? `/${args.baseRoute}/api` : '/api',
+        atlasApiBaseUrl: args.baseRoute ? `/${args.baseRoute}/api` : '/api',
+        authPortalUrl: '',
+      },
+    });
   });
 
-  fastify.get(
-    '/explorer/v1/groups/:projectId/clusters/connectionInfo',
-    async (request, reply) => {
-      const connections = await connectionManager.getAllConnections();
-      reply.send(connections);
-    }
-  );
+  fastify.get('/connection-info', async (_request, reply) => {
+    const connections = await connectionManager.getAllConnections();
+    reply.send(connections);
+  });
 
   // Save connection
-  fastify.post(
-    '/explorer/v1/groups/:projectId/clusters/connectionInfo',
-    async (request, reply) => {
-      const connectionInfo = request.body;
-      if (!connectionInfo) {
-        reply.status(400).send({ error: 'connectionInfo is required' });
-      }
-
-      try {
-        await connectionManager.saveConnectionInfo(connectionInfo);
-        reply.send({ ok: true });
-      } catch (err) {
-        reply.status(400).send({ error: err.message });
-      }
+  fastify.post('/connection-info', async (request, reply) => {
+    const connectionInfo = request.body;
+    if (!connectionInfo) {
+      reply.status(400).send({ error: 'connectionInfo is required' });
     }
-  );
+
+    try {
+      await connectionManager.saveConnectionInfo(connectionInfo);
+      reply.send({ ok: true });
+    } catch (err) {
+      reply.status(400).send({ error: err.message });
+    }
+  });
 
   // Delete connection
-  fastify.delete(
-    '/explorer/v1/groups/:projectId/clusters/connectionInfo/:connectionId',
-    async (request, reply) => {
-      const connectionId = request.params.connectionId;
+  fastify.delete('/connection-info/:connectionId', async (request, reply) => {
+    const connectionId = request.params.connectionId;
 
-      if (!connectionId) {
-        reply.status(400).send({ error: 'connectionId is required' });
-      }
-      try {
-        await connectionManager.deleteConnectionInfo(connectionId);
-        reply.send({ ok: true });
-      } catch (err) {
-        reply.status(400).send({ error: err.message });
-      }
+    if (!connectionId) {
+      reply.status(400).send({ error: 'connectionId is required' });
     }
-  );
-
-  // Settings
-  fastify.get('/settings', (request, reply) => {
-    reply.send(settings);
+    try {
+      await connectionManager.deleteConnectionInfo(connectionId);
+      reply.send({ ok: true });
+    } catch (err) {
+      reply.status(400).send({ error: err.message });
+    }
   });
 
   fastify.post('/settings/optInDataExplorerGenAIFeatures', (request, reply) => {
@@ -445,14 +425,9 @@ module.exports = function (fastify, opts, done) {
   );
 
   fastify.post(
-    '/ai/v1/groups/:projectId/mql-query',
+    '/ai/mql-query',
     { preHandler: fastify.csrfProtection },
     async (request, reply) => {
-      const projectId = request.params.projectId;
-      if (projectId !== args.projectId) {
-        reply.status(400).send({ error: 'Project ID mismatch' });
-      }
-
       if (!args.enableGenAiFeatures) {
         reply.status(400).send({ error: 'Gen AI is not enabled' });
       }
@@ -480,14 +455,9 @@ module.exports = function (fastify, opts, done) {
   );
 
   fastify.post(
-    '/ai/v1/groups/:projectId/mql-aggregation',
+    '/ai/mql-aggregation',
     { preHandler: fastify.csrfProtection },
     async (request, reply) => {
-      const projectId = request.params.projectId;
-      if (projectId !== args.projectId) {
-        reply.status(400).send({ error: 'Project ID mismatch' });
-      }
-
       if (!args.enableGenAiFeatures) {
         reply.status(400).send({ error: 'Gen AI is not enabled' });
       }
@@ -515,11 +485,6 @@ module.exports = function (fastify, opts, done) {
       }
     }
   );
-
-  fastify.setNotFoundHandler((request, reply) => {
-    const csrfToken = reply.generateCsrf();
-    reply.view('index.eta', { csrfToken, appName: args.appName });
-  });
 
   done();
 };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,11 @@
+export function getMetaData(field: string) {
+  const element: HTMLMetaElement | null = document.querySelector(
+    `meta[name="${field}"]`
+  );
+  return element?.content;
+}
+
+export function getAPIRoute(routeName: string) {
+  const baseRoute = getMetaData('base-route');
+  return baseRoute ? `/${baseRoute}/api/${routeName}` : `/api/${routeName}`;
+}

--- a/src/ws.js
+++ b/src/ws.js
@@ -197,20 +197,10 @@ function handleWebsocketConnection(fastify, socket, req) {
  * @param {import('fastify').FastifyPluginOptions} opts
  * @param {import('fastify').FastifyPluginCallback} done
  */
-module.exports = function (fastify, opts, done) {
-  const args = fastify.args;
-
-  fastify.get(
-    '/clusterConnection/:projectId',
-    { websocket: true },
-    (socket, req) => {
-      if (req.params.projectId !== args.projectId) {
-        console.error('Invalid projectId for ws connection');
-        return;
-      }
-      handleWebsocketConnection(fastify, socket, req);
-    }
-  );
+module.exports = function (fastify, _opts, done) {
+  fastify.get('/ws', { websocket: true }, (socket, req) => {
+    handleWebsocketConnection(fastify, socket, req);
+  });
 
   fastify.get('/ws-proxy', { websocket: true }, (socket, req) =>
     handleWebsocketConnection(fastify, socket, req)


### PR DESCRIPTION
Added `--base-route` to support feature request https://github.com/haohanyang/compass-web/issues/18 about sub-path reverse proxy

## Test
Assume compass web is running on `http://localhost:9001` with option `--base-route compass`
### Use `@fastify/http-proxy`
```js
const Fastify = require('fastify');
const server = Fastify();

server.register(require('@fastify/http-proxy'), {
    upstream: 'http://localhost:9001',
    prefix: '/compass',
    rewritePrefix: '/compass',
    websocket: true
});

server.listen({ port: 3000 }, err => {
    if (err) {
        console.error("Error", err)
        process.exit(1)
    }

    console.log("Reverse proxy listening on", 3000)
})
```
### Use Nginx
- nginx.conf
```
server {
    listen 3000;
    server_name _;

    # Proxy /compass to localhost:9001
    location /compass {
        proxy_pass http://localhost:9001;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_redirect off;
    }

    # WebSocket support
    location /compass/ws {
        proxy_pass http://localhost:9001;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "Upgrade";
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_read_timeout 86400;
    }
}
```

Run the docker container
```
docker run --rm \
  -p 3000:3000 \
  --name compass-nginx \
  -v ./nginx.conf:/etc/nginx/conf.d/default.conf:ro \
  --network host \
  nginx:alpine
```

In both cases compass web can be accessed on http://localhost:3000/compass
