### PR TITLE
fix(docker): upgrade libgnutls30 and libgcrypt20 to patch CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,14 @@ RUN npm i -g compass-web@${COMPASS_WEB_VERSION} --no-fund --no-audit \
 FROM node:24-slim
 COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/compass-web/dist/server.js /usr/local/bin/compass-web
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && apt-get upgrade -y --no-install-recommends libgnutls30 libgcrypt20 \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN chown -R node:node /usr/local/lib/node_modules/compass-web
 USER node
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s CMD curl -f http://localhost:8080/healthz || exit 1
 CMD [ "compass-web", "--host", "0.0.0.0" ]
+


### PR DESCRIPTION
## Summary
- Upgrade `libgnutls30` (`3.7.9-2+deb12u6` → `3.7.9-2+deb12u7`) and `libgcrypt20` (`1.10.1-3` → `1.10.1-3+deb12u1`) during the image build, pulling patched versions from `bookworm-security`.
- Resolves all 13 fixable vulnerabilities (2 critical, 3 high, 7 medium, 1 low) flagged in the `compass-web` image scan, all originating from these two Debian 12 base packages.

## Test plan
- [x] `docker build` succeeds
- [x] Re-scan image confirms the 13 fixable CVEs are gone